### PR TITLE
update p4ruby version for Ruby 2.6 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     origen_perforce (0.4.0)
       origen (>= 0.33.0)
-      p4ruby (~> 2017.1, >= 2017.1.1699426)
+      p4ruby (~> 2019.1, >= 2019.1.1873991)
 
 GEM
   remote: https://rubygems.org/
@@ -52,6 +52,8 @@ GEM
     net-ldap (0.16.2)
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.5-x64-mingw32)
+      mini_portile2 (~> 2.4.0)
     origen (0.54.5)
       activesupport (~> 4.1)
       bundler (> 1.7)
@@ -79,7 +81,8 @@ GEM
       yard (~> 0.8)
     origen_doc_helpers (0.8.2)
       origen (>= 0.7.15)
-    p4ruby (2017.1.1699426)
+    p4ruby (2019.1.1873991)
+    p4ruby (2019.1.1873991-x64-mingw32)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
@@ -129,6 +132,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   coveralls

--- a/origen_perforce.gemspec
+++ b/origen_perforce.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
 
   # Add any gems that your plugin needs to run within a host application
   spec.add_runtime_dependency 'origen', '>= 0.33.0'
-  spec.add_runtime_dependency 'p4ruby', '~> 2017.1', '>= 2017.1.1699426'
+  spec.add_runtime_dependency 'p4ruby', '~> 2019.1', '>= 2019.1.1873991'
 end


### PR DESCRIPTION
updated p4ruby to 2019.1 for Ruby 2.6 migration

https://www.perforce.com/perforce/doc.current/user/p4rubynotes.txt 
               Ruby Release | P4Ruby Release
               ===================================
                    2.3     | 2016.1 or later
                    2.4     | 2017.1 or later
                    2.5     | 2019.1 or later
                    2.6     | 2019.1 or later


 2019.1 gem :   https://rubygems.org/gems/p4ruby/versions/2019.1.1873991
